### PR TITLE
Amazon Lex region

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ APP_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 LEX_REFERENCE_CONNECTION=xxxxxx.ngrok.io
 AWS_KEY=xxxxx
 AWS_SECRET=xxxxx
+AWS_REGION=us-east-1
 BOT_NAME=mybotname
 BOT_ALIAS=mybotpublishalias
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ For the next steps, you will need:</br>
 - The Lex reference connection code server public hostname and port (as **`LEX_REFERENCE_CONNECTION`**)</br>
 - The AWS Access Key (as **`AWS_KEY`**)</br>
 - The AWS Secret Key (as **`AWS_SECRET`**)</br>
+- The AWS Region where your Lex bot is set up, e.g. *us-east-1* (as **`AWS_REGION`**)</br>
 - The Lex bot name (as **`BOT_NAME`**)</br>
 - The Lex bot alias (as **`BOT_ALIAS`**)</br>
 

--- a/README.md
+++ b/README.md
@@ -116,13 +116,14 @@ Copy the `.env.example` file over to a new file called `.env`:
 cp .env.example .env
 ```
 
-Edit `.env` file, and set the 8 parameter values:</br>
+Edit `.env` file, and set the 9 parameter values:</br>
 API_KEY=</br>
 API_SECRET=</br>
 APP_ID=</br>
 LEX_REFERENCE_CONNECTION=</br>
 AWS_KEY=</br>
 AWS_SECRET=</br>
+AWS_REGION=</br>
 BOT_NAME=</br>
 BOT_ALIAS=</br>
 
@@ -165,6 +166,7 @@ APP_ID</br>
 LEX_REFERENCE_CONNECTION</br>
 AWS_KEY</br>
 AWS_SECRET</br>
+AWS_REGION</br>
 BOT_NAME</br>
 BOT_ALIAS</br>
 

--- a/lex-voice-application.js
+++ b/lex-voice-application.js
@@ -17,6 +17,7 @@ const apiSecret = process.env.API_SECRET;
 const appId = process.env.APP_ID;
 const awsKey = process.env.AWS_KEY;
 const awsSecret = process.env.AWS_SECRET;
+const awsRegion = process.env.AWS_REGION;
 const lexReferenceConnection = process.env.LEX_REFERENCE_CONNECTION;
 const botName = process.env.BOT_NAME;
 const publishAlias = process.env.BOT_ALIAS;
@@ -67,6 +68,7 @@ app.get('/answer', (req, res) => {
               "headers": {
                 "aws_key": awsKey,
                 "aws_secret": awsSecret,
+                "aws_region": awsRegion,
                 "client_id": uuid + "_" + callerNumber, // Set to any argument as needed by your application logic
                 "webhook_url": "https://" + hostName + "/analytics", // Will receive transcripts and sentiment analysis (if latter is enabled)
                 "sensitivity": 3  // Voice activity detection, possible values 0 (most sensitive) to 3 (least sensitive)


### PR DESCRIPTION
The Amazon Lex region was set by default to _us-east-1_.

Now, you can set the AWS region to match your Lex bot region in the environment variable **AWS_REGION**.
